### PR TITLE
Version 2.0 - Production

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-pca.py
+hw3.py
 YaleB_32x32.npy
-speed.py

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 CS540-testers-SP21
+Copyright (c) 2021 CS540-Testers-SP22
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 CS540-Testers-SP22
+Copyright (c) 2020 CS540-testers , 2021 CS540-testers-SP21 , 2022 CS540-Testers-SP22
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ However, provided that `test.py`, `hw3.py`, and `YaleB_32x32.npy` are all in the
 ### Testing with GitHub Actions
 
 Background: [GitHub Actions](https://github.com/features/actions) is a [CI/CD](https://www.atlassian.com/continuous-delivery/principles/continuous-integration-vs-delivery-vs-deployment) pipeline tool.  
-If you are unfamiliar with `CI/CD`, it is a great process to familiarize yourself with as it is used almost everywhere in industry.  It is a great buzzword for interviews.  For this class, the `CI` portion of the pipeline automatically runs `test.py` any time you push changes to GitHub.  
-You will get an email from GitHub if any of the unit tests fail.  
+If you are unfamiliar with `CI/CD`, it is a great process to familiarize yourself with as it is used almost everywhere in industry.  It is a great buzzword for interviews.  For this class, the `CI` portion of the pipeline automatically runs `test.py` any time you push changes to GitHub.  You will get an email from GitHub if any of the unit tests fail.  
 The `CD` portion creates the `hw\<num>_\<net_id>.zip` file which you can download and turn in to Canvas.  
 I encourage you to give it a try, but it is beyond the scope of this course, and you may always run tests and package the zip file manually.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# unofficial-hw3-tester
+# HW3-Tester
 
 Tests for CS540 Spring 2022 HW3: Principal Component Analysis 
 
@@ -58,4 +58,4 @@ These tests are not endorsed or created by anyone working in an official capacit
 
 By running `test.py`, you are executing code you downloaded from the internet. Back up your files and take a look at what you are running first.
 
-If you have comments or questions, feel free to create an pull request at [https://github.com/JesusVazquez-Code/hw3-tester/pulls]. 
+If you have comments or questions, feel free to create an pull request at [https://github.com/CS540-Tester-SP22/HW3-Tester/pulls]. 

--- a/README.md
+++ b/README.md
@@ -37,8 +37,12 @@ However, provided that `test.py`, `hw3.py`, and `YaleB_32x32.npy` are all in the
 ### Testing with GitHub Actions
 
 Background: [GitHub Actions](https://github.com/features/actions) is a [CI/CD](https://www.atlassian.com/continuous-delivery/principles/continuous-integration-vs-delivery-vs-deployment) pipeline tool.  
-If you are unfamiliar with `CI/CD`, it is a great process to familiarize yourself with as it is used almost everywhere in industry.  It is a great buzzword for interviews.  For this class, the `CI` portion of the pipeline automatically runs `test.py` any time you push changes to GitHub.  You will get an email from GitHub if any of the unit tests fail.  
+
+If you are unfamiliar with `CI/CD`, it is a great process to familiarize yourself with as it is used almost everywhere in industry.  It is a great buzzword for interviews.
+
+For this class, the `CI` portion of the pipeline automatically runs `test.py` any time you push changes to GitHub. You will get an email from GitHub if any of the unit tests fail.  
 The `CD` portion creates the `hw\<num>_\<net_id>.zip` file which you can download and turn in to Canvas.  
+
 I encourage you to give it a try, but it is beyond the scope of this course, and you may always run tests and package the zip file manually.
 
 To set this up, the `yml` file needs to be in a folder named `.github/workflows`. 

--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ One thing to note is Actions is included in a GitHub Pro account.  This comes in
 
 ## Disclaimer
 
-These tests are not endorsed or created by anyone working in an official capacity with UW Madison or any staff for CS540. The tests are make by students, for students.
+These tests are not endorsed or created by anyone working in an official capacity with UW Madison or any staff for CS540. These tests are made by students, for students.
 
 By running `test.py`, you are executing code you downloaded from the internet. Back up your files and take a look at what you are running first.
 
-If you have comments or questions, feel free to create an pull request at [https://github.com/CS540-Tester-SP22/HW3-Tester/pulls]. 
+If you have comments, questions,or contributions -- feel free to create an pull request at [https://github.com/CS540-Tester-SP22/HW3-Tester/pulls]. 
+
+If you have found this page and you are not a student in the Spring 2022 semester -- feel free to create a CS540-Tester github for your respective class and fork from this repo. 

--- a/README.md
+++ b/README.md
@@ -40,8 +40,7 @@ Background: [GitHub Actions](https://github.com/features/actions) is a [CI/CD](h
 
 If you are unfamiliar with `CI/CD`, it is a great process to familiarize yourself with as it is used almost everywhere in industry.  It is a great buzzword for interviews.
 
-For this class, the `CI` portion of the pipeline automatically runs `test.py` any time you push changes to GitHub. You will get an email from GitHub if any of the unit tests fail.  
-The `CD` portion creates the `hw\<num>_\<net_id>.zip` file which you can download and turn in to Canvas.  
+For this class, the `CI` portion of the pipeline automatically runs `test.py` any time you push changes to GitHub. You will get an email from GitHub if any of the unit tests fail. The `CD` portion creates the `hw\<num>_\<net_id>.zip` file which you can download and turn in to Canvas.  
 
 I encourage you to give it a try, but it is beyond the scope of this course, and you may always run tests and package the zip file manually.
 

--- a/README.md
+++ b/README.md
@@ -60,4 +60,6 @@ By running `test.py`, you are executing code you downloaded from the internet. B
 
 If you have comments, questions,or contributions -- feel free to create an pull request at [https://github.com/CS540-Tester-SP22/HW3-Tester/pulls]. 
 
+*** 
 If you have found this page and you are not a student in the Spring 2022 semester -- feel free to create a CS540-Tester github for your respective class and fork from this repo. 
+***

--- a/README.md
+++ b/README.md
@@ -23,40 +23,54 @@ To run the tests, do
 $ python3 test.py
 ```
 
-It is assumed that `YaleB_32x32.npy` is present in the same directory as `test.py` and `hw3.py`. If this is not the case, you can use the argument `--yale-path` like this:
+It is assumed that `YaleB_32x32.npy` is present in the same directory as `test.py` and `hw3.py`. 
+If this is not the case, you can use the argument `--yale-path` like this:
 
 ```bash
 $ python3 test.py --yale-path path/to/YaleB_32x32.npy
 ```
 
-Ideally, you should be running `test.py` using your terminal as this README describes. If you have an issue, first try running it that way. However, provided that `test.py`, `hw3.py`, and `YaleB_32x32.npy` are all in the same directory, it should work if you do `%run test.py` in Jupyter, or run it the same way you would run `hw3.py` in your editor (VS Code, Pycharm, Sublime, etc).
+Ideally, you should be running `test.py` using your terminal as this README describes. 
+If you have an issue, first try running it that way. 
+However, provided that `test.py`, `hw3.py`, and `YaleB_32x32.npy` are all in the same directory, it should work if you do `%run test.py` in Jupyter, or run it the same way you would run `hw3.py` in your editor (VS Code, Pycharm, Sublime, etc).
 
 ### Testing with GitHub Actions
 
-Background: [GitHub Actions](https://github.com/features/actions) is a [CI/CD](https://www.atlassian.com/continuous-delivery/principles/continuous-integration-vs-delivery-vs-deployment) pipeline tool.  If you are unfamiliar with `CI/CD`, it is a great process to familiarize yourself with as it is used almost everywhere in industry.  It is a great buzzword for interviews.  For this class, the `CI` portion of the pipeline automatically runs `test.py` any time you push changes to GitHub.  You will get an email from GitHub if any of the unit tests fail.  The `CD` portion creates the `hw\<num>_\<net_id>.zip` file which you can download and turn in to Canvas.  I encourage you to give it a try, but it is beyond the scope of this course, and you may always run tests and package the zip file manually.
+Background: [GitHub Actions](https://github.com/features/actions) is a [CI/CD](https://www.atlassian.com/continuous-delivery/principles/continuous-integration-vs-delivery-vs-deployment) pipeline tool.  
+If you are unfamiliar with `CI/CD`, it is a great process to familiarize yourself with as it is used almost everywhere in industry.  It is a great buzzword for interviews.  For this class, the `CI` portion of the pipeline automatically runs `test.py` any time you push changes to GitHub.  
+You will get an email from GitHub if any of the unit tests fail.  
+The `CD` portion creates the `hw\<num>_\<net_id>.zip` file which you can download and turn in to Canvas.  
+I encourage you to give it a try, but it is beyond the scope of this course, and you may always run tests and package the zip file manually.
 
-To set this up, the `yml` file needs to be in a folder named `.github/workflows`.  Run this command to copy the `yml` file into your project:
+To set this up, the `yml` file needs to be in a folder named `.github/workflows`. 
+Run this command to copy the `yml` file into your project:
 
 ```bash
 $ cp example_github_actions.yml /path/to/CS540/hw3/.github/workflows/ci.yml
 ```
 
-Then open the `yml` file and edit the `NET_ID` environment variable on line 23.  With this setup, GitHub automatically runs the unit tests in `test.py` whenever you run `git push`.  You will get an email from GitHub if the unit tests fail.  
+Then open the `yml` file and edit the `NET_ID` environment variable on line 23. 
+With this setup, GitHub automatically runs the unit tests in `test.py` whenever you run `git push`. 
+You will get an email from GitHub if the unit tests fail.  
+
 This workflow will also generate the `hw<num>_<NETID>.zip` file you need to turn in.  It can be downloaded by going to the `Actions` tab of the main page of your GitHub repo, scrolling down to artifacts section, and clicking on the file.
 
-Lastly, you will need a `requirements.txt` file in your repo to tell the test script what modules to install from `pip`.  This repo contains a `requirements.txt` file with the modules used in the homework assignment.  Simply copy it to your project:
+Lastly, you will need a `requirements.txt` file in your repo to tell the test script what modules to install from `pip`. 
+This repo contains a `requirements.txt` file with the modules used in the homework assignment.  Simply copy it to your project:
 
 ```bash
 $ cp requirements.txt /path/to/CS540/hw3/
 ```
 
-One thing to note is Actions is included in a GitHub Pro account.  This comes in the [GitHub Student Deveoloper Pack](https://education.github.com/pack) which is free for students and comes with like 300 hours of Actions run time per month or something like that.
+One thing to note is Actions is included in a GitHub Pro account.  
+This comes in the [GitHub Student Deveoloper Pack](https://education.github.com/pack) which is free for students and comes with like 300 hours of Actions run time per month or something like that.
 
 ## Disclaimer
 
 These tests are not endorsed or created by anyone working in an official capacity with UW Madison or any staff for CS540. These tests are made by students, for students.
 
-By running `test.py`, you are executing code you downloaded from the internet. Back up your files and take a look at what you are running first.
+By running `test.py`, you are executing code you downloaded from the internet. 
+Be sure to back up your files and take a look at what you are running first.
 
 If you have comments, questions,or contributions -- feel free to create an pull request at [https://github.com/CS540-Tester-SP22/HW3-Tester/pulls]. 
 

--- a/test.py
+++ b/test.py
@@ -1,29 +1,30 @@
-__maintainer__ = ['CS540-testers-SP22']
-__author__ = ['Nicholas Beninato(SP21)', 'Jesus Vazquez(SP22)']
-__credits__ = ['Harrison Clark(SP21)', 'Stephen Jasina(SP21)', 'Saurabh Kulkarni(SP21)','Alex Moon(SP21)']
-__version__ = 'v0.2.2-modifiedSpring2022'
+'''
+These tests were inspired by and use code from the tests made by 
+cs540-testers-SP21 for the Spring 2021 semester.
 
-import sys
+Their version (1.0) can be found here: 
+    https://github.com/cs540-testers-SP21/hw3-tester/
+
+Subsequently, their version was also inspired by and use code from the tests
+made by cs540-testers for the Fall 2020 semester.
+
+Their version (original) can be found here: 
+    https://github.com/cs540-testers/hw5-tester/
+'''
+
+__maintainer__ = ['CS540-testers-SP22']
+__authors__ = ['Jesus Vazquez']
+__version__ = '2.0 - Production'
+
 import unittest
-from time import time
 import numpy as np
 from hw3 import load_and_center_dataset, get_covariance, get_eig, \
 		get_eig_prop, project_image, display_image
 
 data_path = 'YaleB_32x32.npy'
-
-def timeit(func):
-    def timed_func(*args, **kwargs):
-        t0 = time()
-        out = func(*args, **kwargs)
-        print(f'Ran {func.__name__}{" "*(30-len(func.__name__))}in {(time() - t0)*1000:.2f}ms')
-        return out
-    return timed_func
-
-
+    
 class TestLoadAndCenterDataset(unittest.TestCase):
-	@timeit
-	def test_load(self):
+	def test1_test_load(self):
 		x = load_and_center_dataset(data_path)
 
 		# The dataset needs to have the correct shape
@@ -32,8 +33,7 @@ class TestLoadAndCenterDataset(unittest.TestCase):
 		# The dataset should not be constant-valued
 		self.assertNotAlmostEqual(np.max(x) - np.min(x), 0)
         
-	@timeit
-	def test_center(self):
+	def test2_test_center(self):
 		x = load_and_center_dataset(data_path)
 
 		# Each coordinate of our dataset should average to 0
@@ -41,16 +41,15 @@ class TestLoadAndCenterDataset(unittest.TestCase):
 			self.assertAlmostEqual(np.sum(x[:, i]), 0)
 
 class TestGetCovariance(unittest.TestCase):
-	@timeit
-	def test_shape(self):
+	def test3_test_shape(self):
 		x = load_and_center_dataset(data_path)
 		S = get_covariance(x)
 
 		# S should be square and have side length d
 		self.assertEqual(np.shape(S), (1024, 1024))
 
-	@timeit
-	def test_values(self):
+	
+	def test4_test_values(self):
 		x = load_and_center_dataset(data_path)
 		S = get_covariance(x)
 
@@ -61,8 +60,7 @@ class TestGetCovariance(unittest.TestCase):
 		self.assertTrue(np.min(np.diagonal(S)) >= 0)
 
 class TestGetEig(unittest.TestCase):
-	@timeit
-	def test_small(self):
+	def test5_test_small(self):
 		x = load_and_center_dataset(data_path)
 		S = get_covariance(x)
 		Lambda, U = get_eig(S, 2)
@@ -75,8 +73,8 @@ class TestGetEig(unittest.TestCase):
 		self.assertEqual(np.shape(U), (1024, 2))
 		self.assertTrue(np.all(np.isclose(S @ U, U @ Lambda)))
 
-	@timeit
-	def test_large(self):
+	
+	def test6_test_large(self):
 		x = load_and_center_dataset(data_path)
 		S = get_covariance(x)
 		Lambda, U = get_eig(S, 1024)
@@ -94,8 +92,7 @@ class TestGetEig(unittest.TestCase):
 		self.assertTrue(np.all(np.isclose(S @ U, U @ Lambda)))
 
 class TestGetEigProp(unittest.TestCase):
-	@timeit
-	def test_small(self):
+	def test7_test_small(self):
 		x = load_and_center_dataset(data_path)
 		S = get_covariance(x)
 		Lambda, U = get_eig_prop(S,0.07)
@@ -107,9 +104,8 @@ class TestGetEigProp(unittest.TestCase):
 		# The eigenvectors should be the columns
 		self.assertEqual(np.shape(U), (1024, 2))
 		self.assertTrue(np.all(np.isclose(S @ U, U @ Lambda)))
-
-	@timeit
-	def test_large(self):
+	
+	def test8_test_large(self):
 		x = load_and_center_dataset(data_path)
 		S = get_covariance(x)
 		# This will select all eigenvalues/eigenvectors
@@ -127,56 +123,64 @@ class TestGetEigProp(unittest.TestCase):
 		self.assertEqual(np.shape(U), (1024, 1024))
 		self.assertTrue(np.all(np.isclose(S @ U, U @ Lambda)))
 
-class TestProjectImage(unittest.TestCase):
-	@timeit
-	def test_shape_orig(self):
+class Test5ProjectImage(unittest.TestCase):
+	def test9_test_shape_example(self):
 		x = load_and_center_dataset(data_path)
 		S = get_covariance(x)
 		_, U = get_eig(S, 2)
 		# This is the image of the "9" in the spec
 		projected = project_image(x[0], U)
 
+        # Projected needs to have shape (1024, )
 		self.assertEqual(np.shape(projected), (1024,))
+        
+        # Values from implemenation(Should be correct)
 		self.assertAlmostEqual(np.min(projected), 0.27875793275517147)
 		self.assertAlmostEqual(np.max(projected), 93.22417310945808)
-     
-	@timeit
-	def test_shape_with_two_eig_values(self):
+
+	def test10_test_shape_two_eig_values(self):
 		x = load_and_center_dataset(data_path)
 		S = get_covariance(x)
 		_, U = get_eig(S, 2)
 		# This is the image of the "9" in the spec
 		projected = project_image(x[3], U)
 
+        # Projected needs to have shape (1024, )
 		self.assertEqual(np.shape(projected), (1024,))
+        
+        # Values from implemenation(Should be correct)
 		self.assertAlmostEqual(np.min(projected), -102.98135151709695)
 		self.assertAlmostEqual(np.max(projected), -2.9426401819431263)
      
     # Project_image will be tested with more than 2 eigen values
-	@timeit
-	def test_shape_with_five_eig_values(self):
+ 	
+	def test11_test_shape_five_eig_values(self):
 		x = load_and_center_dataset(data_path)
 		S = get_covariance(x)
 		_, U = get_eig(S, 5)
 		projected = project_image(x[3], U)
 
+        # Projected needs to have shape (1024, )
 		self.assertEqual(np.shape(projected), (1024,))
+        
+        # Values from implemenation(Should be correct)
 		self.assertAlmostEqual(np.min(projected), -25.154139468874448)
 		self.assertAlmostEqual(np.max(projected), 17.02338010385981)
 
-	@timeit
-	def test_shape_with_ten_eig_values(self):
+	def test12_test_shape_ten_eig_values(self):
 		x = load_and_center_dataset(data_path)
 		S = get_covariance(x)
 		_, U = get_eig(S, 10)
 		projected = project_image(x[3], U)
 
+        # Projected needs to have shape (1024, )
 		self.assertEqual(np.shape(projected), (1024,))
+        
+        # Values from implemenation(Should be correct)
 		self.assertAlmostEqual(np.min(projected), -26.8175300968181)
 		self.assertAlmostEqual(np.max(projected), 44.9530102615709)
 
-	@timeit
-	def test_shape_with_eig_values_prop(self):
+	def test13_test_shape_eig_values_prop(self):
 		x = load_and_center_dataset(data_path)
 		S = get_covariance(x)
 		_, U = get_eig_prop(S,0.02)
@@ -190,18 +194,5 @@ class TestProjectImage(unittest.TestCase):
 		self.assertAlmostEqual(np.max(projected), 42.70786536248303)
         
 if __name__ == '__main__':
-	# Hack to allow different locations of YaleB_32x32.npy (
-    # done this way to allow unittest's flags to still 
-    # be passed, if desired)
-	if '--data-path' in sys.argv:
-		path_index = sys.argv.index('--data-path') + 1
-		if path_index == len(sys.argv):
-			print('Error: must supply path after option --data-path')
-			sys.exit(1)
-		data_path = sys.argv[path_index]
-		del(sys.argv[path_index])
-		del(sys.argv[path_index - 1])
-
-	print('Homework 3 Tester Version', __version__)
-
-	unittest.main(argv=sys.argv)
+	print('\nHomework 3 Tester Version', __version__)
+	unittest.main()

--- a/test.py
+++ b/test.py
@@ -1,6 +1,6 @@
-__maintainer__ = ['CS540-testers-SP21']
-__author__ = ['Nicholas Beninato', 'Jesus Vazquez']
-__credits__ = ['Harrison Clark', 'Stephen Jasina', 'Saurabh Kulkarni','Alex Moon', 'Jesus Vazquez']
+__maintainer__ = ['CS540-testers-SP22']
+__author__ = ['Nicholas Beninato(SP21)', 'Jesus Vazquez(SP22)']
+__credits__ = ['Harrison Clark(SP21)', 'Stephen Jasina(SP21)', 'Saurabh Kulkarni(SP21)','Alex Moon(SP21)']
 __version__ = 'v0.2.2-modifiedSpring2022'
 
 import sys
@@ -202,6 +202,6 @@ if __name__ == '__main__':
 		del(sys.argv[path_index])
 		del(sys.argv[path_index - 1])
 
-	print('Homework 5 Tester Version', __version__)
+	print('Homework 3 Tester Version', __version__)
 
 	unittest.main(argv=sys.argv)


### PR DESCRIPTION
To my knowledge, this is a complete test suite for HW3 for Spring 2022. 

- Updates Version to 2.0 - Production
- Adds additional test cases to test project_image that must be passed.
- Modifies main to be simple and straightforward
- test names (hopefully) are now understandable
- Gives proper acknowledgements to all parties involved
- Updates Maintainer in test.py
- Updated README.md, LICENSE, .gitignore

Nuance:
- Test5ProjectImage must have the '5' in its name in order for output to look nice. ( this is due to how unittest.main is implemented. Solution is to put every test under 1 class, however, I believe its beneficial to have the classes separate for readability ) 



